### PR TITLE
feat (TabBar) add position parameter in the tab update api

### DIFF
--- a/src/models/TabBar.coffee
+++ b/src/models/TabBar.coffee
@@ -50,15 +50,17 @@ class TabBar extends EventsSupport
 
     if options.constructor.name == "Object"
       parameters = {}
+      parameters.position = options.position
       parameters.tabs = []
-      for scale in [0...options.tabs.length]
-        parameters.tabs.push(
-          {
-            title: options.tabs[scale].title
-            image_path: options.tabs[scale].icon
-            badge: options.tabs[scale].badge
-          }
-        )
+      if options.tabs
+        for scale in [0...options.tabs.length]
+          parameters.tabs.push(
+            {
+              title: options.tabs[scale].title
+              image_path: options.tabs[scale].icon
+              badge: options.tabs[scale].badge
+            }
+          )
 
     steroids.nativeBridge.nativeCall
       method: "updateTabs"

--- a/testApp/app/controllers/tabbar.coffee
+++ b/testApp/app/controllers/tabbar.coffee
@@ -17,6 +17,21 @@ class window.TabbarController
       onSuccess: -> alert "showed"
       onFailure: -> alert "failed to show"
 
+  @testUpdateTop: ->
+    steroids.tabBar.update {
+      position: 'top'
+    },
+    onSuccess: -> alert "updated"
+    onFailure: -> alert "failed to update"
+
+  @testUpdateBottom: ->
+    steroids.tabBar.update {
+      position: 'bottom'
+    },
+    onSuccess: -> alert "updated"
+    onFailure: -> alert "failed to update"
+
+
   @testUpdate: ->
     steroids.tabBar.update({
       tabs:

--- a/testApp/app/views/tabbar/index.html
+++ b/testApp/app/views/tabbar/index.html
@@ -14,6 +14,14 @@
   <li class="performsTest" data-test="testUpdate">
     update()
   </li>
+
+  <li class="performsTest" data-test="testUpdateTop">
+    update position to top
+  </li>
+  <li class="performsTest" data-test="testUpdateBottom">
+    update position to bottom
+  </li>
+
   <li class="performsTest" data-test="testUpdateTab">
     currentTab.update()
   </li>


### PR DESCRIPTION
New Feature (Fresh Android only for now) : 
on steroids.tabBar.update now we can pass the position of the tab bar.

example:
steroids.tabBar.update({
      position: 'top'
});

steroids.tabBar.update({
      position: 'bottom'
});

the valid values are top and bottom
