### PR TITLE
Feature/android upload support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,6 +79,7 @@ module.exports = function(grunt) {
             'src/PostMessage.coffee',
             'src/models/views/MediaGalleryView.coffee',
             'src/models/Spinner.coffee',
+            'src/models/AndroidUploadSupport.coffee',
             'src/steroids.coffee'
           ]
         }

--- a/src/models/AndroidUploadSupport.coffee
+++ b/src/models/AndroidUploadSupport.coffee
@@ -1,0 +1,101 @@
+class AndroidUploadSupport
+
+  isUploadHeader: (header) ->
+    header == 'X-AG-Image-Uploader' ||
+      header == 'X-AG-Image-Uploader-JPG-Quality' ||
+      header == 'X-AG-Image-Uploader-Scale' ||
+      header == 'X-AG-Image-Uploader-Width' ||
+      header == 'X-AG-Image-Uploader-Height'
+
+  ensureParams: (instance) =>
+    if ! instance.__params
+      instance.__params =
+        headers:{}
+    instance.__params
+
+  addHeader: (params, header, value) -> params.headers[header] = value
+
+  patchSetRequestHeader: () =>
+    applyPatch = (setRequestHeader) =>
+      XMLHttpRequest.prototype.setRequestHeader = (header, value) ->
+        params = @ensureParams this
+        @addHeader params, header, value
+
+        if @isUploadHeader header then params.hasUploadHeaders = true
+
+        setRequestHeader.call this, header, value
+
+    applyPatch XMLHttpRequest.prototype.setRequestHeader
+
+  patchOpen: () =>
+    applyPatch = (open) =>
+      XMLHttpRequest.prototype.open = (method, url, async, user, pass) ->
+        params = @ensureParams this
+        params.method = method
+        params.url = url
+        params.async = async
+        params.user = user
+        params.pass = pass
+
+        open.call this, header, value
+
+    applyPatch XMLHttpRequest.prototype.open
+
+  logTime: (where) =>
+    t1 = performance.now()
+    console.log("[#{where}] took " + (t1 - t0) + " milliseconds.");
+
+  onSuccess = (instance) => () ->
+    @logTime 'sending payload to native API'
+
+  onFailure = (instance) => () ->
+    console.log 'onFailure'
+
+  loadImage: (payload, done) ->
+    fileReader = new FileReader();
+    fileReader.onload = (evt) ->
+      done fileReader.result
+    fileReader.readAsBinaryString payload
+
+  nativeSend: (payload, params) =>
+    @t0 = performance.now()
+
+    @loadImage payload, (data) =>
+      @logTime 'load file contents'
+
+      params.payloadContent = data;
+
+      steroids.nativeBridge.nativeCall
+        method: "xmlHttpRequest"
+        parameters: params
+        successCallbacks: [@onSuccess()]
+        failureCallbacks: [@onFailure]
+
+  #TODO:
+  canUseApiForPayload: (payload) -> true
+
+  patchReadyState: (instance) =>
+    instance.__params.readyState = instance.readyState
+    delete instance.readyState
+    Object.defineProperty instance, 'readyState', {
+      get: -> instance.__params.readyState,
+      enumerable: true
+    }
+
+  patchSend: () =>
+    applyPatch = (send) =>
+      XMLHttpRequest.prototype.send = (payload) =>
+        params = @ensureParams this
+        if params.method == 'PUT' && params.hasUploadHeaders && @canUseApiForPayload(payload)
+          @patchReadyState this
+          this.__params.readyState = 3
+          @nativeSend payload, params
+        else
+          send.call this, header
+
+    applyPatch XMLHttpRequest.prototype.send
+
+  patch: =>
+    @patchSetRequestHeader()
+    @patchOpen()
+    @patchSend()

--- a/src/models/AndroidUploadSupport.coffee
+++ b/src/models/AndroidUploadSupport.coffee
@@ -81,11 +81,16 @@ class AndroidUploadSupport
     event.loaded = loaded
     event.total = total
     event.lengthComputable = lengthComputable
-    instance[fnName](event)
+    try
+      eventFn = instance[fnName]
+      eventFn(event)
+    catch e
+      console.log "Error invoking event: #{fnName}"
 
   onFailure: (instance) => (error) =>
     console.log "onFailure error: #{JSON.stringify(error)}"
     @patchError instance, error
+    @fireProgressEvent instance, "error", 0, 0, true
 
   loadImage: (payload, done) ->
     fileReader = new FileReader();
@@ -175,11 +180,12 @@ class AndroidUploadSupport
       XMLHttpRequest.prototype.send = (payload) ->
         params = getParams this
         if params.method == 'PUT' && params.hasUploadHeaders && canUseApiForPayload(payload)
+
           patchReadyState this
 
           nativeSend this, payload, params
 
-          fireProgressEvent instance, "onloadstart", "loadstart", 0, payload.size, true
+          fireProgressEvent this, "loadstart", 0, payload.size, true
 
           #all info received -> HEADERS_RECEIVED
           params.readyState = 2

--- a/src/models/AndroidUploadSupport.coffee
+++ b/src/models/AndroidUploadSupport.coffee
@@ -83,9 +83,19 @@ class AndroidUploadSupport
     event.lengthComputable = lengthComputable
     try
       eventFn = instance[fnName]
-      eventFn(event)
+      if(eventFn)
+        eventFn(event)
+
+      eventFn = instance.upload[fnName]
+      if(eventFn)
+        eventFn(event)
     catch e
-      console.log "Error invoking event: #{fnName}"
+      console.log "Error invoking event: #{fnName} error: #{JSON.stringify(e)}"
+
+    if(type == "loadend")
+      #upload ended
+      instance.__params.readyState = 4
+      instance.onreadystatechange()
 
   onFailure: (instance) => (error) =>
     console.log "onFailure error: #{JSON.stringify(error)}"
@@ -138,8 +148,8 @@ class AndroidUploadSupport
 
   patchError: (instance, error) =>
     delete instance.error
-    Object.defineProperty instance, 'readyState', {
-      get: -> instance.__params.readyState
+    Object.defineProperty instance, 'error', {
+      get: -> error
       enumerable: true
     }
 
@@ -180,6 +190,7 @@ class AndroidUploadSupport
       XMLHttpRequest.prototype.send = (payload) ->
         params = getParams this
         if params.method == 'PUT' && params.hasUploadHeaders && canUseApiForPayload(payload)
+          this.abort()
 
           patchReadyState this
 

--- a/src/models/AndroidUploadSupport.coffee
+++ b/src/models/AndroidUploadSupport.coffee
@@ -16,86 +16,180 @@ class AndroidUploadSupport
   addHeader: (params, header, value) -> params.headers[header] = value
 
   patchSetRequestHeader: () =>
-    applyPatch = (setRequestHeader) =>
+    getParams = @ensureParams
+    addHeader = @addHeader
+    isUploadHeader = @isUploadHeader
+    applyPatch = (setRequestHeader) ->
       XMLHttpRequest.prototype.setRequestHeader = (header, value) ->
-        params = @ensureParams this
-        @addHeader params, header, value
+        params = getParams this
+        addHeader params, header, value
 
-        if @isUploadHeader header then params.hasUploadHeaders = true
+        if isUploadHeader header then params.hasUploadHeaders = true
 
         setRequestHeader.call this, header, value
 
     applyPatch XMLHttpRequest.prototype.setRequestHeader
 
   patchOpen: () =>
-    applyPatch = (open) =>
+    getParams = @ensureParams
+    applyPatch = (open) ->
       XMLHttpRequest.prototype.open = (method, url, async, user, pass) ->
-        params = @ensureParams this
+        params = getParams this
         params.method = method
         params.url = url
         params.async = async
         params.user = user
         params.pass = pass
+        params.timeout = this.timeout
+        params.withCredentials = this.withCredentials
 
-        open.call this, header, value
+        open.call this, method, url, async, user, pass
 
     applyPatch XMLHttpRequest.prototype.open
 
   logTime: (where) =>
     t1 = performance.now()
-    console.log("[#{where}] took " + (t1 - t0) + " milliseconds.");
+    console.log("[#{where}] took " + (t1 - @t0) + " milliseconds.");
 
-  onSuccess = (instance) => () ->
-    @logTime 'sending payload to native API'
+  onSuccess: (instance) => () =>
+    @logTime 'payload sent to the native API'
 
-  onFailure = (instance) => () ->
-    console.log 'onFailure'
+    #LOADING
+    instance.__params.readyState = 3
+    instance.onreadystatechange()
+
+
+  onProgress: (instance) => (result) =>
+    {event, size, progress} = result
+
+    console.log "onProgress event: #{event} size: #{size} progress: #{progress}"
+
+    if "loadend" == event
+      @logTime 'upload complete by the native API'
+      {status, responseText, responseHeaders} = result
+
+      @patchStatus instance, status
+      @patchResponse instance, responseText
+      @patchGetAllResponseHeaders instance, responseHeaders
+      @patchGetResponseHeader instance, responseHeaders
+
+    @fireProgressEvent instance, event, progress, size, true
+
+  fireProgressEvent: (instance, type, loaded, total, lengthComputable) =>
+    fnName = "on#{type}"
+    event = new ProgressEvent(type)
+    event.loaded = loaded
+    event.total = total
+    event.lengthComputable = lengthComputable
+    instance[fnName](event)
+
+  onFailure: (instance) => (error) =>
+    console.log "onFailure error: #{JSON.stringify(error)}"
+    @patchError instance, error
 
   loadImage: (payload, done) ->
     fileReader = new FileReader();
-    fileReader.onload = (evt) ->
-      done fileReader.result
+    fileReader.onloadend = (evt) ->
+      if fileReader.error
+        throw fileReader.error
+      done btoa(fileReader.result)
     fileReader.readAsBinaryString payload
 
-  nativeSend: (payload, params) =>
+  nativeSend: (instance, payload, params) =>
     @t0 = performance.now()
-
     @loadImage payload, (data) =>
-      @logTime 'load file contents'
+      @logTime 'load file contents into base64 string'
 
       params.payloadContent = data;
+      params.fileName = payload.name
 
       steroids.nativeBridge.nativeCall
         method: "xmlHttpRequest"
         parameters: params
-        successCallbacks: [@onSuccess()]
-        failureCallbacks: [@onFailure]
+        successCallbacks: [@onSuccess(instance)]
+        failureCallbacks: [@onFailure(instance)]
+        recurringCallbacks: [@onProgress(instance)]
 
-  #TODO:
-  canUseApiForPayload: (payload) -> true
+  canUseApiForPayload: (payload) ->
+    extension = payload.name.toLowerCase().substring payload.name.lastIndexOf('.') + 1
+    isImage = "jpg" == extension ||
+                "jpeg" == extension ||
+                "png" == extension ||
+                "ico" == extension
+    #24mb is the size limit to go through the API
+    belowMaxSize = payload.size <= (1000 * 1000 * 24)
+    console.log "size of payload: #{payload.size} bytes - #{(payload.size / 1000 / 1000)} mbs"
+    return isImage && belowMaxSize
+
+  patchGetAllResponseHeaders: (instance, headers) ->
+    instance.getAllResponseHeaders = () ->
+      str = ""
+      for name, value in headers
+        str += "#{name}: #{value}"
+      return str
+
+  patchGetResponseHeader: (instance, headers) ->
+    instance.getResponseHeader = (name) -> headers[name]
+
+  patchError: (instance, error) =>
+    delete instance.error
+    Object.defineProperty instance, 'readyState', {
+      get: -> instance.__params.readyState
+      enumerable: true
+    }
+
+  patchStatus: (instance, status) =>
+    delete instance.status
+    Object.defineProperty instance, 'status', {
+      get: -> status
+      enumerable: true
+    }
+
+  patchResponse: (instance, responseText) =>
+    delete instance.responseText
+    delete instance.response
+    Object.defineProperty instance, 'responseText', {
+      get: -> responseText
+      enumerable: true
+    }
+    Object.defineProperty instance, 'response', {
+      get: -> responseText
+      enumerable: true
+    }
 
   patchReadyState: (instance) =>
     instance.__params.readyState = instance.readyState
     delete instance.readyState
     Object.defineProperty instance, 'readyState', {
-      get: -> instance.__params.readyState,
+      get: -> instance.__params.readyState
       enumerable: true
     }
 
   patchSend: () =>
-    applyPatch = (send) =>
-      XMLHttpRequest.prototype.send = (payload) =>
-        params = @ensureParams this
-        if params.method == 'PUT' && params.hasUploadHeaders && @canUseApiForPayload(payload)
-          @patchReadyState this
-          this.__params.readyState = 3
-          @nativeSend payload, params
+    getParams = @ensureParams
+    patchReadyState = @patchReadyState
+    nativeSend = @nativeSend
+    canUseApiForPayload = @canUseApiForPayload
+    fireProgressEvent = @fireProgressEvent
+    applyPatch = (send) ->
+      XMLHttpRequest.prototype.send = (payload) ->
+        params = getParams this
+        if params.method == 'PUT' && params.hasUploadHeaders && canUseApiForPayload(payload)
+          patchReadyState this
+
+          nativeSend this, payload, params
+
+          fireProgressEvent instance, "onloadstart", "loadstart", 0, payload.size, true
+
+          #all info received -> HEADERS_RECEIVED
+          params.readyState = 2
+          this.onreadystatechange()
         else
-          send.call this, header
+          send.call this, payload
 
     applyPatch XMLHttpRequest.prototype.send
 
-  patch: =>
+  load: ->
     @patchSetRequestHeader()
     @patchOpen()
     @patchSend()

--- a/src/steroids.coffee
+++ b/src/steroids.coffee
@@ -86,6 +86,8 @@ window.steroids =
 # Valid values are subclasses of Bridge
 window.steroids.nativeBridge = Bridge.getBestNativeBridge()
 
+new AndroidUploadSupport().patch() 
+
 # All compnents that perform async operations are here
 window.steroids.waitingForComponents.push("App")
 window.steroids.waitingForComponents.push("Events.focuslisteners")

--- a/src/steroids.coffee
+++ b/src/steroids.coffee
@@ -86,7 +86,8 @@ window.steroids =
 # Valid values are subclasses of Bridge
 window.steroids.nativeBridge = Bridge.getBestNativeBridge()
 
-new AndroidUploadSupport().patch() 
+#load the android upload support
+new AndroidUploadSupport().load() unless ! FreshAndroidBridge.isUsable()
 
 # All compnents that perform async operations are here
 window.steroids.waitingForComponents.push("App")


### PR DESCRIPTION
AndroidUploadSupport patches the XMLHttpRequest obj to be able to intercept Ajax calls in Android.. 

That allow us to intercept ajax requests and delegate to a native API when appropriate.

At the moment we are delegating only PUT requests with the appropriate request headers.
