### PR TITLE
Don't spam console.log events from bridges

### DIFF
--- a/src/bridges/ModuleBridge.coffee
+++ b/src/bridges/ModuleBridge.coffee
@@ -1,3 +1,12 @@
+debug = switch
+  when localStorage.debug? and (localStorage.debug || "").indexOf("steroids") isnt -1
+    (args...) ->
+      console.log "ModuleBridge: ", args...
+  else
+    ->
+      # Swallow debug messages
+
+
 class ModuleBridge extends Bridge
 
   constructor: ()->
@@ -12,7 +21,7 @@ class ModuleBridge extends Bridge
   sendMessageToNative:(messageString)->
     message = JSON.parse(messageString)
 
-    console.log "ModuleBridge: ", message
+    debug message
 
     failed = false
 
@@ -42,7 +51,7 @@ class ModuleBridge extends Bridge
       when "closeModal"
         steroids.component.helper.closeModal()
       else
-        console.log "ModuleBridge: unsupported API method: #{message.method}" unless message.method in failSilentlyMethods
+        debug "unsupported API method: #{message.method}" unless message.method in failSilentlyMethods
         failed = true
 
 

--- a/src/bridges/WebBridge.coffee
+++ b/src/bridges/WebBridge.coffee
@@ -1,3 +1,11 @@
+debug = switch
+  when localStorage.debug? and (localStorage.debug || "").indexOf("steroids") isnt -1
+    (args...) ->
+      console.log "WebBridge: ", args...
+  else
+    ->
+      # Swallow debug messages
+
 class WebBridge extends Bridge
 
   constructor: ()->
@@ -16,12 +24,12 @@ class WebBridge extends Bridge
       , false
 
       source.addEventListener "open", (e)->
-        console.log "Monitoring updates from steroids npm."
+        debug "Monitoring updates from steroids npm."
       , false
 
       source.addEventListener "error", (e)->
         if e.readyState == EventSource.CLOSED
-          console.log "No longer monitoring updates from steroids npm."
+          debug "No longer monitoring updates from steroids npm."
     else
       pollForRefresh = ()->
         xhr = new XMLHttpRequest()
@@ -41,7 +49,7 @@ class WebBridge extends Bridge
   sendMessageToNative:(messageString)->
     message = JSON.parse(messageString)
 
-    console.log "WebBridge: ", message
+    debug message
 
     failed = false
 
@@ -80,7 +88,7 @@ class WebBridge extends Bridge
         document.body.appendChild closeButton
 
       else
-        console.log "WebBridge: unsupported API method: #{message.method}"
+        debug "unsupported API method: #{message.method}"
         failed = true
 
 


### PR DESCRIPTION
Gets rid of console.log spam from WebBridge / ModuleBridge:

![developer_tools_-_http___localhost_4567___connect_connect_html_qrcode_appgyver_3a_2f_2f_3fips_3d_255b_2522192_168_1_145_2522_252c_2522192_168_1_123_2522_255d_26port_3d4567](https://cloud.githubusercontent.com/assets/412022/10968669/6f29bd1e-83cb-11e5-80e7-47d3326becf6.png)

Can be turned on again by setting localStorage.debug to a value that contains the string "steroids". Matches the switch provided by [debug](https://www.npmjs.com/package/debug) but without relying on the npm package, because the build system does not support commonjs dependencies.