### PR TITLE
Allow numbers in navigation bar title

### DIFF
--- a/src/models/NavigationBar.coffee
+++ b/src/models/NavigationBar.coffee
@@ -88,7 +88,7 @@ class NavigationBar
         relativeTo = options.relativeTo ? steroids.app.path
 
         parameters = if title
-          title: title
+          title: String(title)
         else
           titleImagePath: relativeTo + options.titleImagePath
 
@@ -212,10 +212,10 @@ class NavigationBar
       params = {}
 
       if options.constructor.name == "String"
-        params.title = options
+        params.title = String(options)
 
       if options.title?
-        params.title = options.title
+        params.title = String(options.title)
         params.titleImagePath = ""
 
       params.border = options.border

--- a/testApp/app/controllers/navigationbar.coffee
+++ b/testApp/app/controllers/navigationbar.coffee
@@ -100,6 +100,13 @@ class window.NavigationbarController
       onSuccess: -> steroids.logger.log "SUCCESS in showing navigation bar with title"
       onFailure: -> navigator.notification.alert "FAILURE in testShowWithTitle nav bar"
 
+  @testShowWithNumberTitle: ->
+    steroids.view.navigationBar.show {
+      title: 9001
+    },
+      onSuccess: -> steroids.logger.log "SUCCESS in showing navigation bar with number title"
+      onFailure: -> navigator.notification.alert "FAILURE in testShowWithTitle nav bar"
+
   @testShowWithTitleImagePath: ->
     steroids.view.navigationBar.show {
       titleImagePath: "/icons/pill@2x.png"
@@ -173,6 +180,13 @@ class window.NavigationbarController
       title: "New title"
     },
       onSuccess: -> steroids.logger.log "SUCCESS in updating navigationBar title"
+      onFailure: -> navigator.notification.alert "FAILURE in testUpdateTitle"
+
+  @testUpdateNumberTitle: ->
+    steroids.view.navigationBar.update {
+      title: 9001
+    },
+      onSuccess: -> steroids.logger.log "SUCCESS in updating navigationBar title with number"
       onFailure: -> navigator.notification.alert "FAILURE in testUpdateTitle"
 
   @testUpdateTitleImage: ->

--- a/testApp/app/views/navigationbar/index.html
+++ b/testApp/app/views/navigationbar/index.html
@@ -20,6 +20,9 @@
   <a class="performsTest item item-text-wrap" data-location="testShowWithTitle">
     show() with text title
   </a>
+  <a class="performsTest item item-text-wrap" data-location="testShowWithNumberTitle">
+    show() with number title
+  </a>
   <a class="performsTest item item-text-wrap" data-location="testShowWithTitleImagePath">
     show() with titleImagePath
   </a>
@@ -69,6 +72,9 @@
   <h3>Update</h3>
   <a class="performsTest item item-text-wrap" data-location="testUpdateTitle">
     update() with text title
+  </a>
+  <a class="performsTest item item-text-wrap" data-location="testUpdateNumberTitle">
+    update() with number title
   </a>
   <a class="performsTest item item-text-wrap" data-location="testUpdateTitleImage">
     update() with title image


### PR DESCRIPTION
A bug in iOS Scanner 4.0.8 and earlier prevents a value of the `number` type from being set as the title.